### PR TITLE
Add health endpoint test

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,21 +33,25 @@ app.engine('html', renderFile);
 app.set('view engine', 'ejs');
 app.use('/static',express.static('public'));
 app.use(cookieParser());
-app.use(session({
-    secret: "Your secret key",
-    resave: true,
-    saveUninitialized: true,
-    store:  new  MongoStore({
-        mongooseConnection: mongoose.connection,
-        collection: 'session',
-    })
-}));
+if (process.env.NODE_ENV !== 'test') {
+    app.use(session({
+        secret: "Your secret key",
+        resave: true,
+        saveUninitialized: true,
+        store:  new  MongoStore({
+            mongooseConnection: mongoose.connection,
+            collection: 'session',
+        })
+    }));
+}
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(upload.array());
 
 (async () => {
-    await connectMongoDb(process.env.MONGODBKEY);
+    if (process.env.NODE_ENV !== 'test') {
+        await connectMongoDb(process.env.MONGODBKEY);
+    }
 })();
 
 // Health check route

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "start": "ENV=DEV &node ./bin/index.js",
-    "test": "ENV=DEV & cross-env NODE_ENV=test jest --testTimeout=10000 --detectOpenHandles",
+    "test": "cross-env ENV=DEV NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --testTimeout=10000 --detectOpenHandles",
     "dev": "ENV=DEV & nodemon ./bin/index.js",
     "build": "ENV=BUILD & npm install",
     "stage": "ENV=STAGE & pm2 start pm2.json"

--- a/tests/product.test.js
+++ b/tests/product.test.js
@@ -1,18 +1,24 @@
+process.env.GOOGLEID = 'test-id';
+process.env.GOOGLESECRET = 'test-secret';
+process.env.GMAIL = 'test@example.com';
+process.env.PASSWORD = 'password';
+process.env.CLIENTID = 'clientid';
+process.env.CLIENTSECRET = 'clientsecret';
+process.env.REFRESHTOKEN = 'token';
+process.env.MAIL_SERVER = 'smtp.example.com';
 
-const request = require("supertest");
+import request from 'supertest';
 
+let app;
+beforeAll(async () => {
+  app = (await import('../app.js')).default;
+});
 
-
-  it('should understand basic mathematical principles', function() {
-    // We want tests to pass.
-   
-    if (5 == 3) {
-     
-      // Hope we don't get here.
-      throw new Error("Oh no.");
-    }
+describe('GET /health', () => {
+  it('responds with status ok', async () => {
+    await request(app)
+      .get('/health')
+      .expect('Content-Type', /json/)
+      .expect(200, { status: 'ok' });
   });
-
-  
-
-  
+});


### PR DESCRIPTION
## Summary
- add functional test for `/health`
- disable sessions and db connection during tests
- configure Jest for ESM and environment variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a9755bf6c83319ec43e8753cdce0e